### PR TITLE
Публикация в GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy to github.io 
+on:
+  push:
+    branches:
+      - develop 
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v3
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: |
+            mkdocs-material-
+      - run: pip install -r requirements.txt
+      - run: python3 main.py mkdocs --init --all-entities --debug
+      - run: mkdocs gh-deploy --config-file ./build/mkdocs.yml --force


### PR DESCRIPTION
Для ознакомления с проектом предлагаю использовать возможность публикации [mkdocs в GitHub Pages](https://squidfunk.github.io/mkdocs-material/publishing-your-site/). 

Я написал workflow для создания ветки `gh-pages` с собранным mkdocs для GitHub Pages. Пример страницы: https://leitosama.github.io/ERMACK/

После сборки необходимо в [настройках репозитория](https://github.com/Security-Experts-Community/ERMACK/settings/pages) указать ветку `gh-pages` для публикации.

![image](https://github.com/Security-Experts-Community/ERMACK/assets/20799025/8b547222-5791-4024-9d8f-db3e20756538)
